### PR TITLE
TTK-23066 CoreBundle: Fixed pagination service

### DIFF
--- a/src/Pumukit/CoreBundle/Services/PaginationService.php
+++ b/src/Pumukit/CoreBundle/Services/PaginationService.php
@@ -11,20 +11,16 @@ use Pagerfanta\Pagerfanta;
 
 class PaginationService
 {
-    public function createDoctrineODMMongoDBAdapter(Builder $objects, $page = 0, $limit = 0)
+    public function createDoctrineODMMongoDBAdapter(Builder $objects, $page = 1, $limit = 10): Pagerfanta
     {
         [$page, $limit] = $this->validatePagerValues($page, $limit);
-
-        if (0 === $limit) {
-            return $objects->getQuery()->execute();
-        }
 
         $adapter = new DoctrineODMMongoDBAdapter($objects);
 
         return $this->generatePager($adapter, $page, $limit);
     }
 
-    public function createArrayAdapter(array $objects, $page = 0, $limit = 0): Pagerfanta
+    public function createArrayAdapter(array $objects, $page = 1, $limit = 10): Pagerfanta
     {
         [$page, $limit] = $this->validatePagerValues($page, $limit);
 
@@ -33,7 +29,7 @@ class PaginationService
         return $this->generatePager($adapter, $page, $limit);
     }
 
-    public function createDoctrineCollectionAdapter($objects, $page = 0, $limit = 0): Pagerfanta
+    public function createDoctrineCollectionAdapter($objects, $page = 1, $limit = 10): Pagerfanta
     {
         [$page, $limit] = $this->validatePagerValues($page, $limit);
 
@@ -42,12 +38,12 @@ class PaginationService
         return $this->generatePager($adapter, $page, $limit);
     }
 
-    private function generatePager(AdapterInterface $adapter, int $page = 0, int $limit = 0): Pagerfanta
+    private function generatePager(AdapterInterface $adapter, int $page = 1, int $limit = 10): Pagerfanta
     {
         $pager = new Pagerfanta($adapter);
-        $pager->setMaxPerPage($limit);
+        $pager->setMaxPerPage($page);
         $pager->setNormalizeOutOfRangePages(true);
-        $pager->setCurrentPage($page);
+        $pager->setCurrentPage($limit);
 
         return $pager;
     }


### PR DESCRIPTION
* Made sure the public functions always return a Pagerfanta
 the function createDoctrineODMMongoDBAdapter had a logic in which it could return a Cursor, and the
 Controller code expecting a Pagerfanta would break
* Set  and  default values to compatible values
 The value '0' is unsupported by both the setMaxPerPage and the setCurrentPage functions from
 Pagerfanta. This causes the code to break when the service functions are called with their
 defaults