### PR TITLE
Fix create schema without running init commands

### DIFF
--- a/.env
+++ b/.env
@@ -13,7 +13,6 @@
 # Run "composer dump-env prod" to compile .env files for production use (requires symfony/flex >=1.2).
 # https://symfony.com/doc/current/best_practices.html#use-environment-variables-for-infrastructure-configuration
 PUMUKIT_BASE_VERSION=migration_sf4
-RUN_INIT_COMMANDS=false
 
 ###> doctrine/mongodb-odm-bundle ###
 MONGODB_URL=mongodb://db:27017

--- a/.env.travis
+++ b/.env.travis
@@ -13,7 +13,6 @@
 # Run "composer dump-env prod" to compile .env files for production use (requires symfony/flex >=1.2).
 # https://symfony.com/doc/current/best_practices.html#use-environment-variables-for-infrastructure-configuration
 PUMUKIT_BASE_VERSION=migration_sf4
-RUN_INIT_COMMANDS=false
 
 ###> doctrine/mongodb-odm-bundle ###
 MONGODB_URL=mongodb://db:27017

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,6 @@ FROM teltek/pumukit-base:${PUMUKIT_BASE_VERSION}
 ARG APP_ENV=prod
 ARG PHP_MEMORY_LIMIT=512M
 
-ENV RUN_INIT_COMMANDS=false
-
 # copy the code into the docker
 COPY --chown=www-data:www-data . ./
 

--- a/doc/docker/pumukit/docker-entrypoint.sh
+++ b/doc/docker/pumukit/docker-entrypoint.sh
@@ -15,15 +15,14 @@ if [ "$1" = 'php-fpm' ] || [ "$1" = 'bin/console' ]; then
 
     if [ "$APP_ENV" != 'prod' ]; then
         composer install --prefer-dist --no-scripts --no-progress --no-suggest --classmap-authoritative --no-interaction
-        bin/console doctrine:mongodb:schema:create
         set +e
         if [ "$RUN_INIT_COMMANDS" == 'true' ]; then
+            bin/console doctrine:mongodb:schema:create
             bin/console pumukit:init:repo all --force || true
         fi
 
     	if [ "$AUTOCREATE_PUMUKIT_USER" == 'true' ]; then
 	            php bin/console fos:user:create $PUMUKIT_USER $PUMUKIT_USER_MAIL $PUMUKIT_PASS --super-admin || true
-	        
 	    fi
         set -e
     fi

--- a/doc/docker/pumukit/docker-entrypoint.sh
+++ b/doc/docker/pumukit/docker-entrypoint.sh
@@ -16,13 +16,10 @@ if [ "$1" = 'php-fpm' ] || [ "$1" = 'bin/console' ]; then
     if [ "$APP_ENV" != 'prod' ]; then
         composer install --prefer-dist --no-scripts --no-progress --no-suggest --classmap-authoritative --no-interaction
         set +e
-        if [ "$RUN_INIT_COMMANDS" == 'true' ]; then
-            bin/console doctrine:mongodb:schema:create
-            bin/console pumukit:init:repo all --force || true
-        fi
-
+        bin/console doctrine:mongodb:schema:create || true
+        bin/console pumukit:init:repo all --force
     	if [ "$AUTOCREATE_PUMUKIT_USER" == 'true' ]; then
-	            php bin/console fos:user:create $PUMUKIT_USER $PUMUKIT_USER_MAIL $PUMUKIT_PASS --super-admin || true
+	        php bin/console fos:user:create $PUMUKIT_USER $PUMUKIT_USER_MAIL $PUMUKIT_PASS --super-admin || true
 	    fi
         set -e
     fi


### PR DESCRIPTION
Executing 

> doctrine:mongodb:schema:create 

with a database created reports:

> php_1       | Generating optimized autoload files
> php_1       | a collection 'pumukit.Job' already exists.
> php_1       | Created indexes for all classes
