### PR TITLE
TTK-23718 WebTVBundle: Reused multimediaObject tag template for wall

### DIFF
--- a/src/Pumukit/WebTVBundle/Resources/views/Modules/widget_wall.html.twig
+++ b/src/Pumukit/WebTVBundle/Resources/views/Modules/widget_wall.html.twig
@@ -20,13 +20,7 @@
                 </div>
 
                 <div class="wall-labels">
-                    {% for tag in object.getTags() if tag.display %}
-                        <a href="{{ path('pumukit_webtv_search_multimediaobjects', {'tagCod' : tag.getCod() }) }}" title="{{ tag.getTitle() }}">
-                            <span class="label label-default label-pmk">
-                                {{ tag.getTitle() }}
-                            </span>
-                        </a>
-                    {% endfor %}
+                    {% include 'PumukitWebTVBundle:MultimediaObject:template_tags.html.twig' with {'multimediaObject': object} %}
                 </div>
             </div>
         </div>


### PR DESCRIPTION
This fixes issues with tags being shown there that are not shown on the mmobj info