### PR TITLE
TTK-25036 fix test for new release version

### DIFF
--- a/src/Pumukit/SchemaBundle/Repository/MultimediaObjectRepository.php
+++ b/src/Pumukit/SchemaBundle/Repository/MultimediaObjectRepository.php
@@ -265,9 +265,9 @@ class MultimediaObjectRepository extends DocumentRepository
         foreach ($aggregation as $element) {
             if (null !== $element['people']) {
                 if ((null !== $element['people']['cod']) && (null !== $element['people']['people'])) {
-                    if (0 === strpos($element['people']['cod'], $roleCode)) {
+                    if ($element['people']['cod'] === $roleCode) {
                         foreach ($element['people']['people'] as $person) {
-                            if (isset($person['_id']->{'$id'}) && !in_array($person['_id']->{'$id'}, $people)) {
+                            if (isset($person['_id']) && $person['_id']->{'$id'} && !in_array($person['_id']->{'$id'}, $people)) {
                                 $people[] = $person['_id']->{'$id'};
                             }
                         }

--- a/src/Pumukit/SchemaBundle/Tests/Repository/MultimediaObjectRepositoryTest.php
+++ b/src/Pumukit/SchemaBundle/Tests/Repository/MultimediaObjectRepositoryTest.php
@@ -213,10 +213,17 @@ class MultimediaObjectRepositoryTest extends WebTestCase
         $mm4 = $this->createMultimediaObjectAssignedToSeries('MmObject 4', $series_lhazar);
 
         $mm1->addPersonWithRole($person_ned, $role_lord);
+        $mm1->setStatus(MultimediaObject::STATUS_PUBLISHED);
+
         $mm2->addPersonWithRole($person_benjen, $role_ranger);
+        $mm2->setStatus(MultimediaObject::STATUS_PUBLISHED);
+
         $mm3->addPersonWithRole($person_ned, $role_lord);
         $mm3->addPersonWithRole($person_benjen, $role_ranger);
+        $mm3->setStatus(MultimediaObject::STATUS_PUBLISHED);
+
         $mm4->addPersonWithRole($person_ned, $role_hand);
+        $mm4->setStatus(MultimediaObject::STATUS_PUBLISHED);
 
         $this->dm->persist($mm1);
         $this->dm->persist($mm2);
@@ -1850,9 +1857,14 @@ class MultimediaObjectRepositoryTest extends WebTestCase
         $this->dm->flush();
 
         $mm1 = $this->createMultimediaObjectAssignedToSeries('mm1', $series1);
+        $mm1->setStatus(MultimediaObject::STATUS_PUBLISHED);
         $mm2 = $this->createMultimediaObjectAssignedToSeries('mm2', $series1);
+        $mm2->setStatus(MultimediaObject::STATUS_PUBLISHED);
         $mm3 = $this->createMultimediaObjectAssignedToSeries('mm3', $series2);
+        $mm3->setStatus(MultimediaObject::STATUS_PUBLISHED);
         $mm4 = $this->createMultimediaObjectAssignedToSeries('mm4', $series3);
+        $mm4->setStatus(MultimediaObject::STATUS_PUBLISHED);
+        $this->dm->flush();
 
         $this->assertEquals(4, $this->repo->count());
         $this->assertEquals(492, $this->repo->countDuration());


### PR DESCRIPTION
* testCreateMultimediaObjectAndFindByCriteria

findByPersonId search multimedia objects with status not equals to NEW or PROTOTYPE.  
createMultimediaObjectAssignedToSeries creates new Multimedia Object with status NEW.

* testCount

MultimediaObjectRepository count() method find MultimediaObject with status not equals to NEW or PROTOTYPE.
createMultimediaObjectAssignedToSeries creates new Multimedia Object with status NEW.


* findPeopleWithRoleCode

Fix wrong bugfix make on https://github.com/pumukit/PuMuKIT/commit/b756fd45de6e233ebd76172a7ed2c261b22c8abc


